### PR TITLE
Fix OnChange event with post nil if the note is the same

### DIFF
--- a/Source/VirtualTrees.BaseTree.pas
+++ b/Source/VirtualTrees.BaseTree.pas
@@ -12607,7 +12607,7 @@ begin
       if NeedChangeEvent then
       begin
         Invalidate;
-        Change(nil);
+        Change(HitInfo.HitNode);
       end;
     end
     else if (toAlwaysSelectNode in Self.TreeOptions.SelectionOptions) then


### PR DESCRIPTION
I’m submitting a fix for the OnChange event, which incorrectly set the node to nil when clicking on an already selected node. This behavior is incorrect. The event should always provide the node being switched to; otherwise, nil would mean that no node is selected at all. Moreover, this worked differently in earlier versions of VT, where the parameter was never nil.