### PR TITLE
Fix missing scope and removed unused units

### DIFF
--- a/Tests/Tests.dpr
+++ b/Tests/Tests.dpr
@@ -4,7 +4,7 @@ program Tests;
 {$APPTYPE CONSOLE}
 {$ENDIF}{$STRONGLINKTYPES ON}
 uses
-  SysUtils,
+  System.SysUtils,
   {$IFDEF TESTINSIGHT}
   TestInsight.DUnitX,
   {$ENDIF }

--- a/Tests/Tests.dproj
+++ b/Tests/Tests.dproj
@@ -7,7 +7,7 @@
         <MainSource>Tests.dpr</MainSource>
         <Platform Condition="'$(Platform)'==''">Win32</Platform>
         <ProjectGuid>{D37CFA56-3B13-4C93-91F7-DDC227C20116}</ProjectGuid>
-        <ProjectVersion>20.3</ProjectVersion>
+        <ProjectVersion>20.4</ProjectVersion>
         <TargetedPlatforms>3</TargetedPlatforms>
         <ProjectName Condition="'$(ProjectName)'==''">Tests</ProjectName>
     </PropertyGroup>
@@ -725,6 +725,9 @@
                     <Platform Name="Win64x">
                         <Operation>1</Operation>
                     </Platform>
+                    <Platform Name="WinARM64EC">
+                        <Operation>1</Operation>
+                    </Platform>
                 </DeployClass>
                 <DeployClass Name="ProjectiOSDeviceDebug">
                     <Platform Name="iOSDevice32">
@@ -763,6 +766,10 @@
                         <RemoteDir>Assets</RemoteDir>
                         <Operation>1</Operation>
                     </Platform>
+                    <Platform Name="WinARM64EC">
+                        <RemoteDir>Assets</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
                 </DeployClass>
                 <DeployClass Name="UWP_DelphiLogo44">
                     <Platform Name="Win32">
@@ -770,6 +777,10 @@
                         <Operation>1</Operation>
                     </Platform>
                     <Platform Name="Win64">
+                        <RemoteDir>Assets</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="WinARM64EC">
                         <RemoteDir>Assets</RemoteDir>
                         <Operation>1</Operation>
                     </Platform>
@@ -986,6 +997,7 @@
                 <ProjectRoot Platform="Win32" Name="$(PROJECTNAME)"/>
                 <ProjectRoot Platform="Win64" Name="$(PROJECTNAME)"/>
                 <ProjectRoot Platform="Win64x" Name="$(PROJECTNAME)"/>
+                <ProjectRoot Platform="WinARM64EC" Name="$(PROJECTNAME)"/>
             </Deployment>
         </BorlandProject>
         <ProjectFileVersion>12</ProjectFileVersion>

--- a/Tests/VTOnEditCancelledTests.pas
+++ b/Tests/VTOnEditCancelledTests.pas
@@ -4,7 +4,6 @@ interface
 
 uses
   DUnitX.TestFramework,
-  Classes,
   Vcl.Forms,
   VirtualTrees;
 
@@ -30,7 +29,6 @@ type
 implementation
 
 uses
-  VirtualTrees.WorkerThread, VirtualTrees.EditLink,
   System.SysUtils;
 
 procedure TVTOnEditCancelledTests.Setup;


### PR DESCRIPTION
Fixed missing scope and removed unused units in Tests.dproj and VTOnEditCancelledTests.pas.
Fixes #1327.