### PR TITLE
Fixes OnChange event #1347

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ Packages/RAD Studio XE3/VirtualTreesR.lib
 # Folder with repro projects #
 ##############################
 /#*
+Tests/dunitx-results.xml
+Tests/TestInsightSettings.ini

--- a/Demos/Advanced/VisibilityDemo.dfm
+++ b/Demos/Advanced/VisibilityDemo.dfm
@@ -8202,7 +8202,7 @@ object VisibilityForm: TVisibilityForm
       TreeOptions.MiscOptions = [toAcceptOLEDrop, toCheckSupport, toInitOnSave, toToggleOnDblClick, toWheelPanning]
       TreeOptions.PaintOptions = [toHideFocusRect, toShowBackground, toShowButtons, toShowDropmark, toShowRoot, toShowTreeLines, toThemeAware, toUseBlendedImages, toUseBlendedSelection]
       TreeOptions.SelectionOptions = [toExtendedFocus, toFullRowSelect]
-      OnChange = VST2Change
+      OnChange = VST3Change
       OnCollapsed = VSTCollapsedExpanded
       OnExpanded = VSTCollapsedExpanded
       OnFreeNode = VST3FreeNode
@@ -8260,6 +8260,7 @@ object VisibilityForm: TVisibilityForm
     TabOrder = 0
     TreeOptions.AutoOptions = [toAutoDropExpand, toAutoScroll, toAutoScrollOnExpand, toAutoTristateTracking, toAutoHideButtons, toAutoChangeScale]
     TreeOptions.SelectionOptions = [toMultiSelect]
+    OnChange = VST1Change
     OnFreeNode = VST1FreeNode
     OnGetText = VST1GetText
     OnInitChildren = VST1InitChildren

--- a/Demos/Advanced/VisibilityDemo.pas
+++ b/Demos/Advanced/VisibilityDemo.pas
@@ -40,6 +40,7 @@ type
     procedure VST2Scroll(Sender: TBaseVirtualTree; DeltaX, DeltaY: TDimension);
     procedure VSTCollapsedExpanded(Sender: TBaseVirtualTree; Node: PVirtualNode);
     procedure VST2Change(Sender: TBaseVirtualTree; Node: PVirtualNode);
+    procedure VST3Change(Sender: TBaseVirtualTree; Node: PVirtualNode);
     procedure Splitter2CanResize(Sender: TObject; var NewSize: Integer;
       var Accept: Boolean);
     procedure Splitter2Paint(Sender: TObject);
@@ -47,11 +48,15 @@ type
       var CellText: string);
     procedure FormShow(Sender: TObject);
     procedure FormHide(Sender: TObject);
+    procedure VST1Change(Sender: TBaseVirtualTree; Node: PVirtualNode);
     procedure VST3FreeNode(Sender: TBaseVirtualTree; Node: PVirtualNode);
     procedure VST2FreeNode(Sender: TBaseVirtualTree; Node: PVirtualNode);
     procedure VST1FreeNode(Sender: TBaseVirtualTree; Node: PVirtualNode);
+	procedure VSTChange(Sender: TBaseVirtualTree; Node: PVirtualNode);
+
   private
     FChanging: Boolean;
+    procedure ShowNode(const Source: string; Node: PVirtualNode);
     procedure HideNodes(Sender: TBaseVirtualTree; Node: PVirtualNode; Data: Pointer; var Abort: Boolean);
   end;
 
@@ -263,7 +268,14 @@ end;
 
 //----------------------------------------------------------------------------------------------------------------------
 
-procedure TVisibilityForm.VST2Change(Sender: TBaseVirtualTree; Node: PVirtualNode);
+procedure TVisibilityForm.ShowNode(const Source: string; Node: PVirtualNode);
+begin
+  OutputDebugString(PChar(Format('%s %s Node: %p', [FormatDateTime('hh:nn:ss', Now), Source, Pointer(Node)])));
+end;
+
+//----------------------------------------------------------------------------------------------------------------------
+
+procedure TVisibilityForm.VSTChange(Sender: TBaseVirtualTree; Node: PVirtualNode);
 
 // Keep selected nodes in sync.
 
@@ -288,6 +300,22 @@ begin
       FChanging := False;
     end;
   end;
+end;
+
+//----------------------------------------------------------------------------------------------------------------------
+
+procedure TVisibilityForm.VST2Change(Sender: TBaseVirtualTree; Node: PVirtualNode);
+begin
+  ShowNode('VST2', Node);
+  VSTChange(Sender, Node);
+end;
+
+//----------------------------------------------------------------------------------------------------------------------
+
+procedure TVisibilityForm.VST3Change(Sender: TBaseVirtualTree; Node: PVirtualNode);
+begin
+  ShowNode('VST3', Node);
+  VSTChange(Sender, Node);
 end;
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -338,6 +366,12 @@ procedure TVisibilityForm.FormHide(Sender: TObject);
 
 begin
   StateForm.Show;
+end;
+
+procedure TVisibilityForm.VST1Change(Sender: TBaseVirtualTree; Node:
+    PVirtualNode);
+begin
+  ShowNode('VST1', Node);
 end;
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/Source/VirtualTrees.Types.pas
+++ b/Source/VirtualTrees.Types.pas
@@ -78,6 +78,7 @@ const
   StructureChangeTimer     = 6;
   SearchTimer              = 7;
   ThemeChangedTimer        = 8;
+  ChangeCellTimer          = 9;
 
   ThemeChangedTimerDelay   = 500;
 
@@ -544,7 +545,8 @@ type
     tsVCLDragFinished,        // Flag to avoid triggering the OnColumnClick event twice
     tsPanning,                // Mouse panning is active.
     tsWindowCreating,         // Set during window handle creation to avoid frequent unnecessary updates.
-    tsUseExplorerTheme        // The tree runs under WinVista+ and is using the explorer theme
+    tsUseExplorerTheme,       // The tree runs under WinVista+ and is using the explorer theme
+    tsChangeCellPending       // A cell selection change is pending.
   );
 
 

--- a/Source/VirtualTrees.pas
+++ b/Source/VirtualTrees.pas
@@ -472,6 +472,7 @@ type
     property OnCanSplitterResizeHeader;
     property OnCanSplitterResizeNode;
     property OnChange;
+    property OnChangeCell;
     property OnChecked;
     property OnChecking;
     property OnClick;

--- a/Tests/Tests.dpr
+++ b/Tests/Tests.dpr
@@ -16,7 +16,8 @@ uses
   VTWorkerThreadIssue1001Tests in 'VTWorkerThreadIssue1001Tests.pas',
   VTOnEditCancelledTests in 'VTOnEditCancelledTests.pas',
   VTOnDrawTextTests in 'VTOnDrawTextTests.pas',
-  VTCellSelectionTests in 'VTCellSelectionTests.pas';
+  VTCellSelectionTests in 'VTCellSelectionTests.pas',
+  VirtualTrees.MouseUtils in 'VirtualTrees.MouseUtils.pas';
 
 var
   runner : ITestRunner;

--- a/Tests/Tests.dproj
+++ b/Tests/Tests.dproj
@@ -7,7 +7,7 @@
         <MainSource>Tests.dpr</MainSource>
         <Platform Condition="'$(Platform)'==''">Win32</Platform>
         <ProjectGuid>{D37CFA56-3B13-4C93-91F7-DDC227C20116}</ProjectGuid>
-        <ProjectVersion>19.2</ProjectVersion>
+        <ProjectVersion>20.3</ProjectVersion>
         <TargetedPlatforms>3</TargetedPlatforms>
         <ProjectName Condition="'$(ProjectName)'==''">Tests</ProjectName>
     </PropertyGroup>
@@ -84,6 +84,8 @@
         <DCC_Define>madExcept;$(DCC_Define)</DCC_Define>
         <DCC_MapFile>3</DCC_MapFile>
         <DCC_RemoteDebug>false</DCC_RemoteDebug>
+        <VerInfo_Locale>1033</VerInfo_Locale>
+        <AppDPIAwarenessMode>none</AppDPIAwarenessMode>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_1_Win64)'!=''">
         <DCC_MapFile>3</DCC_MapFile>
@@ -104,15 +106,16 @@
         <DCCReference Include="VTOnEditCancelledTests.pas"/>
         <DCCReference Include="VTOnDrawTextTests.pas"/>
         <DCCReference Include="VTCellSelectionTests.pas"/>
-        <BuildConfiguration Include="Release">
-            <Key>Cfg_2</Key>
-            <CfgParent>Base</CfgParent>
-        </BuildConfiguration>
+        <DCCReference Include="VirtualTrees.MouseUtils.pas"/>
         <BuildConfiguration Include="Base">
             <Key>Base</Key>
         </BuildConfiguration>
         <BuildConfiguration Include="Debug">
             <Key>Cfg_1</Key>
+            <CfgParent>Base</CfgParent>
+        </BuildConfiguration>
+        <BuildConfiguration Include="Release">
+            <Key>Cfg_2</Key>
             <CfgParent>Base</CfgParent>
         </BuildConfiguration>
     </ItemGroup>
@@ -124,7 +127,11 @@
                 <Source>
                     <Source Name="MainSource">Tests.dpr</Source>
                 </Source>
-                <Excluded_Packages/>
+                <Excluded_Packages>
+                    <Excluded_Packages Name="C:\Users\Public\Documents\Embarcadero\Studio\23.0\Bpl\MakeRegisteredTypeLibraryWindowBetter.bpl">(untitled)</Excluded_Packages>
+                    <Excluded_Packages Name="$(BDSBIN)\dcloffice2k290.bpl">Microsoft Office 2000 Sample Automation Server Wrapper Components</Excluded_Packages>
+                    <Excluded_Packages Name="$(BDSBIN)\dclofficexp290.bpl">Microsoft Office XP Sample Automation Server Wrapper Components</Excluded_Packages>
+                </Excluded_Packages>
             </Delphi.Personality>
             <Platforms>
                 <Platform value="Win32">True</Platform>

--- a/Tests/VirtualTrees.MouseUtils.pas
+++ b/Tests/VirtualTrees.MouseUtils.pas
@@ -1,0 +1,145 @@
+unit VirtualTrees.MouseUtils;
+
+interface
+
+uses
+  VirtualTrees, System.Types;
+
+type
+
+  /// <summary>
+  /// Created to be used only for testing
+  /// </summary>
+  TCustomVirtualStringTreeMouseHelper = class helper for TCustomVirtualStringTree
+  public
+    function GetDisplayRectEx(ANode: PVirtualNode; AColumn: TColumnIndex): TPoint;
+    procedure MouseClick(ACursorPos: TPoint); overload;
+    procedure MouseClick(ANode: PVirtualNode; AColumn: TColumnIndex = 0); overload;
+    procedure ShiftMouseClick(ANode: PVirtualNode; AColumn: TColumnIndex = 0); overload;
+  end;
+
+implementation
+
+uses
+  Winapi.Windows, Vcl.Controls, Winapi.Messages, VirtualTrees.Types, System.Math,
+  System.SysUtils;
+
+{ TCustomVirtualStringTreeMouseHelper }
+
+
+function TCustomVirtualStringTreeMouseHelper.GetDisplayRectEx(ANode: PVirtualNode; AColumn: TColumnIndex): TPoint;
+var
+  R: TRect;
+  LRight: TDimension;
+begin
+  if not Assigned(ANode) then
+  begin
+    Result := Point(0, 0);
+    Exit;
+  end;
+
+  // Use the full-row rect to get a reliable Y coordinate for hit testing.
+  R := GetDisplayRect(ANode, NoColumn, False, False, False);
+
+  if R.IsEmpty then
+  begin
+    Exit(Point(0, 0));
+  end;
+
+  Result.Y := R.Top + (R.Bottom - R.Top) div 2;
+  Header.Columns.GetColumnBounds(AColumn, Result.X, LRight);
+
+  // If header is visible the client coordinates for hit testing are below the header.
+  if hoVisible in Header.Options then
+    Inc(Result.Y, Header.Height);
+end;
+
+procedure TCustomVirtualStringTreeMouseHelper.MouseClick(ACursorPos: TPoint);
+const
+  KEYDOWN = Byte(1 shl 7);
+var
+  LKeyboardState: TKeyboardState;
+  LTree: TCustomVirtualStringTree;
+  LSavedCursorPos: TPoint;
+  LWPARAM: WPARAM;
+  LPos: LPARAM;
+begin
+  // Click a new cell on the tree...
+  LTree := Self;
+  LSavedCursorPos := Mouse.CursorPos;
+  try
+    Mouse.CursorPos := ACursorPos;
+    LWPARAM := MK_LBUTTON;
+    if GetKeyboardState(LKeyboardState) then
+      begin
+        if (LKeyboardState[VK_SHIFT] and KEYDOWN <> 0) or
+           (LKeyboardState[VK_LSHIFT] and KEYDOWN <> 0) or
+           (LKeyboardState[VK_RSHIFT] and KEYDOWN <> 0) then
+          LWPARAM := LWPARAM or MK_SHIFT;
+        if (LKeyboardState[VK_CONTROL] and KEYDOWN <> 0) or
+           (LKeyboardState[VK_LCONTROL] and KEYDOWN <> 0) or
+           (LKeyboardState[VK_RCONTROL] and KEYDOWN <> 0) then
+          LWPARAM := LWPARAM or MK_CONTROL;
+      end;
+    LPos := MakeLParam(ACursorPos.X, ACursorPos.Y);
+    LTree.Perform(WM_LBUTTONDOWN, LWPARAM, LPos);
+    LTree.Perform(WM_LBUTTONUP, LWPARAM, LPos);
+  finally
+    Mouse.CursorPos := LSavedCursorPos;
+  end;
+end;
+
+procedure TCustomVirtualStringTreeMouseHelper.MouseClick(ANode: PVirtualNode;
+  AColumn: TColumnIndex = 0
+);
+var
+  LTree: TCustomVirtualStringTree;
+  LClientRect, LClientRect2: TRect;
+  LHitInfo: THitInfo;
+  LTopLeft: TPoint;
+  LPasses, LCount: Integer;
+begin
+  LTree := Self;
+  if not Assigned(ANode) then
+    Exit;
+
+  LClientRect := LTree.GetDisplayRect(ANode, AColumn, True, True, True);
+  LTopLeft := LClientRect.TopLeft;
+  if hoVisible in LTree.Header.Options then
+    begin
+      Inc(LTopLeft.Y, LTree.Header.Height);
+    end;
+
+  LPasses := 0;
+  LCount := LTree.VisibleCount;
+  repeat
+    LTree.GetHitTestInfoAt(LTopLeft.X, LTopLeft.Y, True, LHitInfo, []);
+    LClientRect2 := LTree.GetDisplayRect(LHitInfo.HitNode, AColumn, True);
+    if LHitInfo.HitNode <> ANode then
+      Inc(LTopLeft.Y, LHitInfo.HitNode.NodeHeight);
+    Inc(LPasses); // Prevent forever loop
+  until (LHitInfo.HitNode = ANode) or (LPasses > LCount);
+  Assert((LHitInfo.HitNode = ANode) and (LHitInfo.HitColumn = AColumn));
+
+  MouseClick(LTopLeft);
+end;
+
+procedure TCustomVirtualStringTreeMouseHelper.ShiftMouseClick(
+  ANode: PVirtualNode; AColumn: TColumnIndex = 0);
+const
+  KEYDOWN = Byte(1 shl 7);
+var
+  LOrigKBState, LNewKBState: TKeyboardState;
+begin
+  GetKeyboardState(LOrigKBState);
+  LNewKBState := LOrigKBState;
+  LNewKBState[VK_SHIFT] := LOrigKBState[VK_SHIFT] or KEYDOWN;
+  SetKeyboardState(LNewKBState);
+  try
+    MouseClick(ANode, AColumn);
+  finally
+    SetKeyboardState(LOrigKBState);
+  end;
+end;
+
+end.


### PR DESCRIPTION
Fixes OnChange event #1347 
Updated VisibilityDemo to show debug messages when OnChange for VSTs are fired. 
Calls ClearCellSelection when VST.Clear is called. 
Fixes clipboard tests in VTCellSelectionTests to no longer require 10 tests each. 
Created/Moved (Shift)MouseClick to VirtualTrees.MouseUtils under test directory. 
Added tests for OnChange, OnChangeCell, Clear, and updated Clipboard tests to use a fixed font and size as it affects the output.