### PR TITLE
Removes implicit warnings when compiling

### DIFF
--- a/Packages/RAD Studio 10.1/VirtualTreesR.dpk
+++ b/Packages/RAD Studio 10.1/VirtualTreesR.dpk
@@ -34,24 +34,27 @@ requires
   vclx;
 
 contains
-  VirtualTrees in '..\..\Source\VirtualTrees.pas',
-  VirtualTrees.HeaderPopup in '..\..\Source\VirtualTrees.HeaderPopup.pas',
-  VirtualTrees.AccessibilityFactory in '..\..\Source\VirtualTrees.AccessibilityFactory.pas',
   VirtualTrees.Accessibility in '..\..\Source\VirtualTrees.Accessibility.pas',
-  VirtualTrees.StyleHooks in '..\..\Source\VirtualTrees.StyleHooks.pas',
-  VirtualTrees.Classes in '..\..\Source\VirtualTrees.Classes.pas',
-  VirtualTrees.WorkerThread in '..\..\Source\VirtualTrees.WorkerThread.pas',
-  VirtualTrees.ClipBoard in '..\..\Source\VirtualTrees.ClipBoard.pas',
+  VirtualTrees.AccessibilityFactory in '..\..\Source\VirtualTrees.AccessibilityFactory.pas',
   VirtualTrees.Actions in '..\..\Source\VirtualTrees.Actions.pas',
-  VirtualTrees.Export in '..\..\Source\VirtualTrees.Export.pas',
-  VirtualTrees.Utils in '..\..\Source\VirtualTrees.Utils.pas',
-  VirtualTrees.Types in '..\..\Source\VirtualTrees.Types.pas',
-  VirtualTrees.Header in '..\..\Source\VirtualTrees.Header.pas',
-  VirtualTrees.DataObject in '..\..\Source\VirtualTrees.DataObject.pas',
-  VirtualTrees.DragnDrop in '..\..\Source\VirtualTrees.DragnDrop.pas',
-  VirtualTrees.DragImage in '..\..\Source\VirtualTrees.DragImage.pas',
-  VirtualTrees.EditLink in '..\..\Source\VirtualTrees.EditLink.pas',
+  VirtualTrees.Classes in '..\..\Source\VirtualTrees.Classes.pas',
+  VirtualTrees.ClipBoard in '..\..\Source\VirtualTrees.ClipBoard.pas',
   VirtualTrees.Colors in '..\..\Source\VirtualTrees.Colors.pas',
-  VirtualTrees.DrawTree in '..\..\Source\VirtualTrees.DrawTree.pas';
+  VirtualTrees.DataObject in '..\..\Source\VirtualTrees.DataObject.pas',
+  VirtualTrees.DragImage in '..\..\Source\VirtualTrees.DragImage.pas',
+  VirtualTrees.DragnDrop in '..\..\Source\VirtualTrees.DragnDrop.pas',
+  VirtualTrees.DrawTree in '..\..\Source\VirtualTrees.DrawTree.pas',
+  VirtualTrees.EditLink in '..\..\Source\VirtualTrees.EditLink.pas',
+  VirtualTrees.Export in '..\..\Source\VirtualTrees.Export.pas',
+  VirtualTrees.Header in '..\..\Source\VirtualTrees.Header.pas',
+  VirtualTrees.HeaderPopup in '..\..\Source\VirtualTrees.HeaderPopup.pas',
+  VirtualTrees in '..\..\source\VirtualTrees.pas',
+  VirtualTrees.BaseTree in '..\..\source\VirtualTrees.BaseTree.pas',
+  VirtualTrees.AncestorVCL in '..\..\source\VirtualTrees.AncestorVCL.pas',
+  VirtualTrees.BaseAncestorVCL in '..\..\source\VirtualTrees.BaseAncestorVCL.pas',
+  VirtualTrees.StyleHooks in '..\..\Source\VirtualTrees.StyleHooks.pas',
+  VirtualTrees.Types in '..\..\Source\VirtualTrees.Types.pas',
+  VirtualTrees.Utils in '..\..\Source\VirtualTrees.Utils.pas',
+  VirtualTrees.WorkerThread in '..\..\Source\VirtualTrees.WorkerThread.pas';
 
 end.

--- a/Packages/RAD Studio 10.1/VirtualTreesR.dproj
+++ b/Packages/RAD Studio 10.1/VirtualTreesR.dproj
@@ -79,25 +79,28 @@
         </DelphiCompile>
         <DCCReference Include="vcl.dcp"/>
         <DCCReference Include="vclx.dcp"/>
-        <DCCReference Include="..\..\Source\VirtualTrees.pas"/>
-        <DCCReference Include="..\..\Source\VirtualTrees.HeaderPopup.pas"/>
-        <DCCReference Include="..\..\Source\VirtualTrees.AccessibilityFactory.pas"/>
         <DCCReference Include="..\..\Source\VirtualTrees.Accessibility.pas"/>
-        <DCCReference Include="..\..\Source\VirtualTrees.StyleHooks.pas"/>
-        <DCCReference Include="..\..\Source\VirtualTrees.Classes.pas"/>
-        <DCCReference Include="..\..\Source\VirtualTrees.WorkerThread.pas"/>
-        <DCCReference Include="..\..\Source\VirtualTrees.ClipBoard.pas"/>
+        <DCCReference Include="..\..\Source\VirtualTrees.AccessibilityFactory.pas"/>
         <DCCReference Include="..\..\Source\VirtualTrees.Actions.pas"/>
-        <DCCReference Include="..\..\Source\VirtualTrees.Export.pas"/>
-        <DCCReference Include="..\..\Source\VirtualTrees.Utils.pas"/>
-        <DCCReference Include="..\..\Source\VirtualTrees.Types.pas"/>
-        <DCCReference Include="..\..\Source\VirtualTrees.Header.pas"/>
-        <DCCReference Include="..\..\Source\VirtualTrees.DataObject.pas"/>
-        <DCCReference Include="..\..\Source\VirtualTrees.DragnDrop.pas"/>
-        <DCCReference Include="..\..\Source\VirtualTrees.DragImage.pas"/>
-        <DCCReference Include="..\..\Source\VirtualTrees.EditLink.pas"/>
+        <DCCReference Include="..\..\Source\VirtualTrees.Classes.pas"/>
+        <DCCReference Include="..\..\Source\VirtualTrees.ClipBoard.pas"/>
         <DCCReference Include="..\..\Source\VirtualTrees.Colors.pas"/>
+        <DCCReference Include="..\..\Source\VirtualTrees.DataObject.pas"/>
+        <DCCReference Include="..\..\Source\VirtualTrees.DragImage.pas"/>
+        <DCCReference Include="..\..\Source\VirtualTrees.DragnDrop.pas"/>
         <DCCReference Include="..\..\Source\VirtualTrees.DrawTree.pas"/>
+        <DCCReference Include="..\..\Source\VirtualTrees.EditLink.pas"/>
+        <DCCReference Include="..\..\Source\VirtualTrees.Export.pas"/>
+        <DCCReference Include="..\..\Source\VirtualTrees.Header.pas"/>
+        <DCCReference Include="..\..\Source\VirtualTrees.HeaderPopup.pas"/>
+        <DCCReference Include="..\..\source\VirtualTrees.pas"/>
+        <DCCReference Include="..\..\source\VirtualTrees.BaseTree.pas"/>
+        <DCCReference Include="..\..\source\VirtualTrees.AncestorVCL.pas"/>
+        <DCCReference Include="..\..\source\VirtualTrees.BaseAncestorVCL.pas"/>
+        <DCCReference Include="..\..\Source\VirtualTrees.StyleHooks.pas"/>
+        <DCCReference Include="..\..\Source\VirtualTrees.Types.pas"/>
+        <DCCReference Include="..\..\Source\VirtualTrees.Utils.pas"/>
+        <DCCReference Include="..\..\Source\VirtualTrees.WorkerThread.pas"/>
         <BuildConfiguration Include="Debug">
             <Key>Cfg_2</Key>
             <CfgParent>Base</CfgParent>

--- a/Packages/RAD Studio 10.2/VirtualTreesR.dpk
+++ b/Packages/RAD Studio 10.2/VirtualTreesR.dpk
@@ -34,24 +34,27 @@ requires
   vclx;
 
 contains
-  VirtualTrees in '..\..\Source\VirtualTrees.pas',
-  VirtualTrees.HeaderPopup in '..\..\Source\VirtualTrees.HeaderPopup.pas',
-  VirtualTrees.AccessibilityFactory in '..\..\Source\VirtualTrees.AccessibilityFactory.pas',
   VirtualTrees.Accessibility in '..\..\Source\VirtualTrees.Accessibility.pas',
-  VirtualTrees.StyleHooks in '..\..\Source\VirtualTrees.StyleHooks.pas',
-  VirtualTrees.Classes in '..\..\Source\VirtualTrees.Classes.pas',
-  VirtualTrees.WorkerThread in '..\..\Source\VirtualTrees.WorkerThread.pas',
-  VirtualTrees.ClipBoard in '..\..\Source\VirtualTrees.ClipBoard.pas',
+  VirtualTrees.AccessibilityFactory in '..\..\Source\VirtualTrees.AccessibilityFactory.pas',
   VirtualTrees.Actions in '..\..\Source\VirtualTrees.Actions.pas',
-  VirtualTrees.Export in '..\..\Source\VirtualTrees.Export.pas',
-  VirtualTrees.Utils in '..\..\Source\VirtualTrees.Utils.pas',
-  VirtualTrees.Types in '..\..\Source\VirtualTrees.Types.pas',
-  VirtualTrees.Header in '..\..\Source\VirtualTrees.Header.pas',
-  VirtualTrees.DataObject in '..\..\Source\VirtualTrees.DataObject.pas',
-  VirtualTrees.DragnDrop in '..\..\Source\VirtualTrees.DragnDrop.pas',
-  VirtualTrees.DragImage in '..\..\Source\VirtualTrees.DragImage.pas',
-  VirtualTrees.EditLink in '..\..\Source\VirtualTrees.EditLink.pas',
+  VirtualTrees.Classes in '..\..\Source\VirtualTrees.Classes.pas',
+  VirtualTrees.ClipBoard in '..\..\Source\VirtualTrees.ClipBoard.pas',
   VirtualTrees.Colors in '..\..\Source\VirtualTrees.Colors.pas',
-  VirtualTrees.DrawTree in '..\..\Source\VirtualTrees.DrawTree.pas';
+  VirtualTrees.DataObject in '..\..\Source\VirtualTrees.DataObject.pas',
+  VirtualTrees.DragImage in '..\..\Source\VirtualTrees.DragImage.pas',
+  VirtualTrees.DragnDrop in '..\..\Source\VirtualTrees.DragnDrop.pas',
+  VirtualTrees.DrawTree in '..\..\Source\VirtualTrees.DrawTree.pas',
+  VirtualTrees.EditLink in '..\..\Source\VirtualTrees.EditLink.pas',
+  VirtualTrees.Export in '..\..\Source\VirtualTrees.Export.pas',
+  VirtualTrees.Header in '..\..\Source\VirtualTrees.Header.pas',
+  VirtualTrees.HeaderPopup in '..\..\Source\VirtualTrees.HeaderPopup.pas',
+  VirtualTrees in '..\..\source\VirtualTrees.pas',
+  VirtualTrees.BaseTree in '..\..\source\VirtualTrees.BaseTree.pas',
+  VirtualTrees.AncestorVCL in '..\..\source\VirtualTrees.AncestorVCL.pas',
+  VirtualTrees.BaseAncestorVCL in '..\..\source\VirtualTrees.BaseAncestorVCL.pas',
+  VirtualTrees.StyleHooks in '..\..\Source\VirtualTrees.StyleHooks.pas',
+  VirtualTrees.Types in '..\..\Source\VirtualTrees.Types.pas',
+  VirtualTrees.Utils in '..\..\Source\VirtualTrees.Utils.pas',
+  VirtualTrees.WorkerThread in '..\..\Source\VirtualTrees.WorkerThread.pas';
 
 end.

--- a/Packages/RAD Studio 10.2/VirtualTreesR.dproj
+++ b/Packages/RAD Studio 10.2/VirtualTreesR.dproj
@@ -79,25 +79,28 @@
         </DelphiCompile>
         <DCCReference Include="vcl.dcp"/>
         <DCCReference Include="vclx.dcp"/>
-        <DCCReference Include="..\..\Source\VirtualTrees.pas"/>
-        <DCCReference Include="..\..\Source\VirtualTrees.HeaderPopup.pas"/>
-        <DCCReference Include="..\..\Source\VirtualTrees.AccessibilityFactory.pas"/>
         <DCCReference Include="..\..\Source\VirtualTrees.Accessibility.pas"/>
-        <DCCReference Include="..\..\Source\VirtualTrees.StyleHooks.pas"/>
-        <DCCReference Include="..\..\Source\VirtualTrees.Classes.pas"/>
-        <DCCReference Include="..\..\Source\VirtualTrees.WorkerThread.pas"/>
-        <DCCReference Include="..\..\Source\VirtualTrees.ClipBoard.pas"/>
+        <DCCReference Include="..\..\Source\VirtualTrees.AccessibilityFactory.pas"/>
         <DCCReference Include="..\..\Source\VirtualTrees.Actions.pas"/>
-        <DCCReference Include="..\..\Source\VirtualTrees.Export.pas"/>
-        <DCCReference Include="..\..\Source\VirtualTrees.Utils.pas"/>
-        <DCCReference Include="..\..\Source\VirtualTrees.Types.pas"/>
-        <DCCReference Include="..\..\Source\VirtualTrees.Header.pas"/>
-        <DCCReference Include="..\..\Source\VirtualTrees.DataObject.pas"/>
-        <DCCReference Include="..\..\Source\VirtualTrees.DragnDrop.pas"/>
-        <DCCReference Include="..\..\Source\VirtualTrees.DragImage.pas"/>
-        <DCCReference Include="..\..\Source\VirtualTrees.EditLink.pas"/>
+        <DCCReference Include="..\..\Source\VirtualTrees.Classes.pas"/>
+        <DCCReference Include="..\..\Source\VirtualTrees.ClipBoard.pas"/>
         <DCCReference Include="..\..\Source\VirtualTrees.Colors.pas"/>
+        <DCCReference Include="..\..\Source\VirtualTrees.DataObject.pas"/>
+        <DCCReference Include="..\..\Source\VirtualTrees.DragImage.pas"/>
+        <DCCReference Include="..\..\Source\VirtualTrees.DragnDrop.pas"/>
         <DCCReference Include="..\..\Source\VirtualTrees.DrawTree.pas"/>
+        <DCCReference Include="..\..\Source\VirtualTrees.EditLink.pas"/>
+        <DCCReference Include="..\..\Source\VirtualTrees.Export.pas"/>
+        <DCCReference Include="..\..\Source\VirtualTrees.Header.pas"/>
+        <DCCReference Include="..\..\Source\VirtualTrees.HeaderPopup.pas"/>
+        <DCCReference Include="..\..\source\VirtualTrees.pas"/>
+        <DCCReference Include="..\..\source\VirtualTrees.BaseTree.pas"/>
+        <DCCReference Include="..\..\source\VirtualTrees.AncestorVCL.pas"/>
+        <DCCReference Include="..\..\source\VirtualTrees.BaseAncestorVCL.pas"/>
+        <DCCReference Include="..\..\Source\VirtualTrees.StyleHooks.pas"/>
+        <DCCReference Include="..\..\Source\VirtualTrees.Types.pas"/>
+        <DCCReference Include="..\..\Source\VirtualTrees.Utils.pas"/>
+        <DCCReference Include="..\..\Source\VirtualTrees.WorkerThread.pas"/>
         <BuildConfiguration Include="Debug">
             <Key>Cfg_2</Key>
             <CfgParent>Base</CfgParent>

--- a/Packages/RAD Studio 10/VirtualTreesR.dpk
+++ b/Packages/RAD Studio 10/VirtualTreesR.dpk
@@ -34,24 +34,27 @@ requires
   vclx;
 
 contains
-  VirtualTrees in '..\..\Source\VirtualTrees.pas',
-  VirtualTrees.HeaderPopup in '..\..\Source\VirtualTrees.HeaderPopup.pas',
-  VirtualTrees.AccessibilityFactory in '..\..\Source\VirtualTrees.AccessibilityFactory.pas',
   VirtualTrees.Accessibility in '..\..\Source\VirtualTrees.Accessibility.pas',
-  VirtualTrees.StyleHooks in '..\..\Source\VirtualTrees.StyleHooks.pas',
-  VirtualTrees.Classes in '..\..\Source\VirtualTrees.Classes.pas',
-  VirtualTrees.WorkerThread in '..\..\Source\VirtualTrees.WorkerThread.pas',
-  VirtualTrees.ClipBoard in '..\..\Source\VirtualTrees.ClipBoard.pas',
+  VirtualTrees.AccessibilityFactory in '..\..\Source\VirtualTrees.AccessibilityFactory.pas',
   VirtualTrees.Actions in '..\..\Source\VirtualTrees.Actions.pas',
-  VirtualTrees.Export in '..\..\Source\VirtualTrees.Export.pas',
-  VirtualTrees.Utils in '..\..\Source\VirtualTrees.Utils.pas',
-  VirtualTrees.Types in '..\..\Source\VirtualTrees.Types.pas',
-  VirtualTrees.Header in '..\..\Source\VirtualTrees.Header.pas',
-  VirtualTrees.DataObject in '..\..\Source\VirtualTrees.DataObject.pas',
-  VirtualTrees.DragnDrop in '..\..\Source\VirtualTrees.DragnDrop.pas',
-  VirtualTrees.DragImage in '..\..\Source\VirtualTrees.DragImage.pas',
-  VirtualTrees.EditLink in '..\..\Source\VirtualTrees.EditLink.pas',
+  VirtualTrees.Classes in '..\..\Source\VirtualTrees.Classes.pas',
+  VirtualTrees.ClipBoard in '..\..\Source\VirtualTrees.ClipBoard.pas',
   VirtualTrees.Colors in '..\..\Source\VirtualTrees.Colors.pas',
-  VirtualTrees.DrawTree in '..\..\Source\VirtualTrees.DrawTree.pas';
+  VirtualTrees.DataObject in '..\..\Source\VirtualTrees.DataObject.pas',
+  VirtualTrees.DragImage in '..\..\Source\VirtualTrees.DragImage.pas',
+  VirtualTrees.DragnDrop in '..\..\Source\VirtualTrees.DragnDrop.pas',
+  VirtualTrees.DrawTree in '..\..\Source\VirtualTrees.DrawTree.pas',
+  VirtualTrees.EditLink in '..\..\Source\VirtualTrees.EditLink.pas',
+  VirtualTrees.Export in '..\..\Source\VirtualTrees.Export.pas',
+  VirtualTrees.Header in '..\..\Source\VirtualTrees.Header.pas',
+  VirtualTrees.HeaderPopup in '..\..\Source\VirtualTrees.HeaderPopup.pas',
+  VirtualTrees in '..\..\source\VirtualTrees.pas',
+  VirtualTrees.BaseTree in '..\..\source\VirtualTrees.BaseTree.pas',
+  VirtualTrees.AncestorVCL in '..\..\source\VirtualTrees.AncestorVCL.pas',
+  VirtualTrees.BaseAncestorVCL in '..\..\source\VirtualTrees.BaseAncestorVCL.pas',
+  VirtualTrees.StyleHooks in '..\..\Source\VirtualTrees.StyleHooks.pas',
+  VirtualTrees.Types in '..\..\Source\VirtualTrees.Types.pas',
+  VirtualTrees.Utils in '..\..\Source\VirtualTrees.Utils.pas',
+  VirtualTrees.WorkerThread in '..\..\Source\VirtualTrees.WorkerThread.pas';
 
 end.

--- a/Packages/RAD Studio 10/VirtualTreesR.dproj
+++ b/Packages/RAD Studio 10/VirtualTreesR.dproj
@@ -79,25 +79,28 @@
         </DelphiCompile>
         <DCCReference Include="vcl.dcp"/>
         <DCCReference Include="vclx.dcp"/>
-        <DCCReference Include="..\..\Source\VirtualTrees.pas"/>
-        <DCCReference Include="..\..\Source\VirtualTrees.HeaderPopup.pas"/>
-        <DCCReference Include="..\..\Source\VirtualTrees.AccessibilityFactory.pas"/>
         <DCCReference Include="..\..\Source\VirtualTrees.Accessibility.pas"/>
-        <DCCReference Include="..\..\Source\VirtualTrees.StyleHooks.pas"/>
-        <DCCReference Include="..\..\Source\VirtualTrees.Classes.pas"/>
-        <DCCReference Include="..\..\Source\VirtualTrees.WorkerThread.pas"/>
-        <DCCReference Include="..\..\Source\VirtualTrees.ClipBoard.pas"/>
+        <DCCReference Include="..\..\Source\VirtualTrees.AccessibilityFactory.pas"/>
         <DCCReference Include="..\..\Source\VirtualTrees.Actions.pas"/>
-        <DCCReference Include="..\..\Source\VirtualTrees.Export.pas"/>
-        <DCCReference Include="..\..\Source\VirtualTrees.Utils.pas"/>
-        <DCCReference Include="..\..\Source\VirtualTrees.Types.pas"/>
-        <DCCReference Include="..\..\Source\VirtualTrees.Header.pas"/>
-        <DCCReference Include="..\..\Source\VirtualTrees.DataObject.pas"/>
-        <DCCReference Include="..\..\Source\VirtualTrees.DragnDrop.pas"/>
-        <DCCReference Include="..\..\Source\VirtualTrees.DragImage.pas"/>
-        <DCCReference Include="..\..\Source\VirtualTrees.EditLink.pas"/>
+        <DCCReference Include="..\..\Source\VirtualTrees.Classes.pas"/>
+        <DCCReference Include="..\..\Source\VirtualTrees.ClipBoard.pas"/>
         <DCCReference Include="..\..\Source\VirtualTrees.Colors.pas"/>
+        <DCCReference Include="..\..\Source\VirtualTrees.DataObject.pas"/>
+        <DCCReference Include="..\..\Source\VirtualTrees.DragImage.pas"/>
+        <DCCReference Include="..\..\Source\VirtualTrees.DragnDrop.pas"/>
         <DCCReference Include="..\..\Source\VirtualTrees.DrawTree.pas"/>
+        <DCCReference Include="..\..\Source\VirtualTrees.EditLink.pas"/>
+        <DCCReference Include="..\..\Source\VirtualTrees.Export.pas"/>
+        <DCCReference Include="..\..\Source\VirtualTrees.Header.pas"/>
+        <DCCReference Include="..\..\Source\VirtualTrees.HeaderPopup.pas"/>
+        <DCCReference Include="..\..\source\VirtualTrees.pas"/>
+        <DCCReference Include="..\..\source\VirtualTrees.BaseTree.pas"/>
+        <DCCReference Include="..\..\source\VirtualTrees.AncestorVCL.pas"/>
+        <DCCReference Include="..\..\source\VirtualTrees.BaseAncestorVCL.pas"/>
+        <DCCReference Include="..\..\Source\VirtualTrees.StyleHooks.pas"/>
+        <DCCReference Include="..\..\Source\VirtualTrees.Types.pas"/>
+        <DCCReference Include="..\..\Source\VirtualTrees.Utils.pas"/>
+        <DCCReference Include="..\..\Source\VirtualTrees.WorkerThread.pas"/>
         <BuildConfiguration Include="Debug">
             <Key>Cfg_2</Key>
             <CfgParent>Base</CfgParent>


### PR DESCRIPTION
Fixes #1351 
Removes implicit warnings when compiling by adding missing units.